### PR TITLE
Add if modifier to `validates`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ class VideoValidator
 end
 ```
 
+Validator execution on specific fields can be run or skipped at validation time
+by passing an `if` validator proc, which decides if the validation should run
+```ruby
+class PersonValidator
+  include Subvalid::Validator
+
+  validates :postcode, presence: true, if: -> (person) { person.country == "US" }
+end
+```
+
 ## Contact
 
 - [github project](https://github.com/envato/subvalid)

--- a/lib/subvalid/validator_registry.rb
+++ b/lib/subvalid/validator_registry.rb
@@ -2,7 +2,7 @@ module Subvalid
   class ValidatorRegistry
     class << self
       def [](key)
-        validators[key] or raise "no validator with key=#{key}"
+        validators[key] or raise ArgumentError.new("no validator with key=#{key}")
       end
 
       def register(key, validator)

--- a/spec/subvalid/validator_registry_spec.rb
+++ b/spec/subvalid/validator_registry_spec.rb
@@ -13,7 +13,7 @@ describe Subvalid::ValidatorRegistry do
 
     context "when validator doesn't exist" do
       it "raises an error" do
-        expect { described_class[:bad_key] }.to raise_error
+        expect { described_class[:bad_key] }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
Allow validation to be dynamically run or skipped depending on return value of proc passed to an `if` key in `.validates` options.

e.g.

``` ruby
validates :postcode, presence: true, if: -> (person) { person.country == "US" }
```

TODO
- [X] implement `if` logic
- [X] tests passing
- [X] readme updated with usage docs
- [ ] refactor modifier implementation to reduce responsibilities in `Subvalid::Validators` module. It's getting a bit crowded in there.
