### PR TITLE
Added a 'minimum' option to the Length validator

### DIFF
--- a/lib/subvalid/validators/length_validator.rb
+++ b/lib/subvalid/validators/length_validator.rb
@@ -6,6 +6,8 @@ module Subvalid
         args = args.to_h
         args.each do |operator, value|
           case operator
+          when :minimum
+            validation_result.add_error("is too short, minimum is #{value}") if object.size < value
           when :maximum
             validation_result.add_error("is too long, maximum is #{value}") if object.size > value
             # TODO ALL the other operators from http://guides.rubyonrails.org/active_record_validations.html#length

--- a/spec/subvalid/validator_spec.rb
+++ b/spec/subvalid/validator_spec.rb
@@ -17,13 +17,6 @@ describe Subvalid::Validator do
     end
   end
 
-  class TestValidator
-    def self.validate(object, validation_result=ValidationResult.new, *args)
-      validation_result.add_error("testing #{object}")
-    end
-  end
-  Subvalid::ValidatorRegistry.register(:test, TestValidator)
-
   Poro = Struct.new(:foo, :bar, :child, :some_predicate) do
     def to_s
       "I'M A PORO"

--- a/spec/subvalid/validators/length_validator_spec.rb
+++ b/spec/subvalid/validators/length_validator_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe Subvalid::Validators::LengthValidator do
+  Thing = Struct.new(:list)
+  class ThingValidator
+    include Subvalid::Validator
+    validates :list, length: {minimum: 2, maximum: 4}
+  end
+
+  let(:thing) { Thing.new(list) }
+  let(:list) { [] }
+
+  describe '#validate' do
+    subject(:validator) { ThingValidator.validate(thing) }
+
+    it 'returns a validation result' do
+      expect(validator).to be_a(Subvalid::ValidationResult)
+    end
+
+    context 'when the length is just right' do
+      let(:list) { [:a] * 3 }
+      it { is_expected.to be_valid }
+    end
+
+    context 'when the length is too short' do
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when the length is too long' do
+      let(:list) { [:a] * 5 }
+      it { is_expected.not_to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
Usage eg:

``` ruby
class TestVal
  includes Subvalid::Validator
  validates :foo, :length {minimum:2}
end
```

would validate that foo has a length of at least 2
