### PR TITLE
Update length validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rvm:
   - 2.5.1
   - 2.3.8
   - ruby-head
-  - jruby-9.0.0.0
+  - jruby-9.2.7.0
 before_install:
   - gem install bundler --no-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
-  - 2.2.2
-  - 2.1.6
-  - 2.0.0
+  - 2.6.0
+  - 2.5.1
+  - 2.3.0
   - ruby-head
   - jruby-9.0.0.0
+before_install:
+  - gem install bundler --no-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.6.0
+  - 2.6.3
+  - 2.5.5
   - 2.5.1
-  - 2.3.0
+  - 2.3.8
   - ruby-head
   - jruby-9.0.0.0
 before_install:

--- a/README.md
+++ b/README.md
@@ -164,6 +164,35 @@ class PersonValidator
 end
 ```
 
+### Length Options
+
+You can specify length constraints in different ways:
+
+```ruby
+class PersonValidator
+  include Subvalid::Validator
+
+  validates :name, length: { minimum: 2 }
+  validates :bio, length: { maximum: 500 }
+  validates :password, length: { in: 6..20 }
+  validates :registration_number, length: { is: 6 }
+end
+```
+
+The possible length constraint options are:
+
+`:minimum` - The attribute cannot have less than the specified length.
+
+`:maximum` - The attribute cannot have more than the specified length.
+
+`:in` (or `:within`) - The attribute length must be included in a given interval. The value for this option must be a range.
+
+`:is` - The attribute length must be equal to the given value.
+
+The default error messages depend on the type of length validation being performed. You can use the `:message` option to specify an error message.
+
+Note that the default error messages are plural. A personalised message should be provided in cases where it is grammatically incorrect, eg, "cannot be shorter than 1 characters".
+
 ## Contact
 
 - [github project](https://github.com/envato/subvalid)

--- a/lib/subvalid/validators/length_validator.rb
+++ b/lib/subvalid/validators/length_validator.rb
@@ -6,6 +6,8 @@ module Subvalid
         args = args.to_h
         args.each do |operator, value|
           case operator
+          when :minimum
+            validation_result.add_error("is too short, minimum is #{value}") if object.size < value
           when :maximum
             validation_result.add_error("is too long, maximum is #{value}") if object.size > value
             # TODO ALL the other operators from http://guides.rubyonrails.org/active_record_validations.html#length

--- a/lib/subvalid/validators/length_validator.rb
+++ b/lib/subvalid/validators/length_validator.rb
@@ -14,9 +14,9 @@ module Subvalid
           when :is
             validation_result.add_error(message || "should have exactly #{value} characters") if object.size != value
           when :in, :within
-            validation_result.add_error(
-              message || "should contain #{value.first} to #{value.last} characters"
-            ) unless value.include? object.size
+            unless value.include?(object.size)
+              validation_result.add_error(message || "should contain #{value.first} to #{value.last} characters")
+            end
           else
             raise "don't know what to do with operator=#{operator}"
           end

--- a/lib/subvalid/validators/length_validator.rb
+++ b/lib/subvalid/validators/length_validator.rb
@@ -4,13 +4,19 @@ module Subvalid
       def self.validate(object, validation_result=ValidationResult.new, *args)
         return unless object
         args = args.to_h
+        message = args.delete(:message)
         args.each do |operator, value|
           case operator
           when :minimum
-            validation_result.add_error("is too short, minimum is #{value}") if object.size < value
+            validation_result.add_error(message || "cannot be shorter than #{value} characters") if object.size < value
           when :maximum
-            validation_result.add_error("is too long, maximum is #{value}") if object.size > value
-            # TODO ALL the other operators from http://guides.rubyonrails.org/active_record_validations.html#length
+            validation_result.add_error(message || "cannot be longer than #{value} characters") if object.size > value
+          when :is
+            validation_result.add_error(message || "should have exactly #{value} characters") if object.size != value
+          when :in, :within
+            validation_result.add_error(
+              message || "should contain #{value.first} to #{value.last} characters"
+            ) unless value.include? object.size
           else
             raise "don't know what to do with operator=#{operator}"
           end

--- a/lib/subvalid/version.rb
+++ b/lib/subvalid/version.rb
@@ -1,3 +1,3 @@
 module Subvalid
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/subvalid/validator_spec.rb
+++ b/spec/subvalid/validator_spec.rb
@@ -17,13 +17,6 @@ describe Subvalid::Validator do
     end
   end
 
-  class TestValidator
-    def self.validate(object, validation_result=ValidationResult.new, *args)
-      validation_result.add_error("testing #{object}")
-    end
-  end
-  Subvalid::ValidatorRegistry.register(:test, TestValidator)
-
   Poro = Struct.new(:foo, :bar, :child, :some_predicate) do
     def to_s
       "I'M A PORO"

--- a/spec/subvalid/validators/length_validator_spec.rb
+++ b/spec/subvalid/validators/length_validator_spec.rb
@@ -2,33 +2,178 @@ require "spec_helper"
 
 describe Subvalid::Validators::LengthValidator do
   Thing = Struct.new(:list)
-  class ThingValidator
-    include Subvalid::Validator
-    validates :list, length: {minimum: 2, maximum: 4}
-  end
-
   let(:thing) { Thing.new(list) }
   let(:list) { [] }
 
   describe '#validate' do
-    subject(:validator) { ThingValidator.validate(thing) }
+    context 'when attribute is a string' do
+      context 'with minimum' do
+        class MinValidator
+          include Subvalid::Validator
+          validates :list, length: {minimum: 2}
+        end
 
-    it 'returns a validation result' do
-      expect(validator).to be_a(Subvalid::ValidationResult)
+        subject(:validator) { MinValidator.validate(thing) }
+
+        it 'returns a validation result' do
+          expect(validator).to be_a(Subvalid::ValidationResult)
+        end
+
+        context 'when the length is just right' do
+          let(:list) { 'a' * 3 }
+          it { is_expected.to be_valid }
+        end
+
+        context 'when the length is too short' do
+          it { is_expected.not_to be_valid }
+
+          it 'shows the default error message' do
+            expect(validator.children[:list].errors).to include("cannot be shorter than 2 characters")
+          end
+        end
+      end
+
+      context 'with maximum' do
+        class MaxValidator
+          include Subvalid::Validator
+          validates :list, length: {maximum: 10}
+        end
+
+        subject(:validator) { MaxValidator.validate(thing) }
+
+        it 'returns a validation result' do
+          expect(validator).to be_a(Subvalid::ValidationResult)
+        end
+
+        context 'when the length is just right' do
+          it { is_expected.to be_valid }
+        end
+
+        context 'when the length is too long' do
+          let(:list) { 'a' * 30 }
+          it { is_expected.not_to be_valid }
+
+          it 'shows the default error message' do
+            expect(validator.children[:list].errors).to include("cannot be longer than 10 characters")
+          end
+        end
+      end
+
+      context 'with exact character count' do
+        class ExactLengthValidator
+          include Subvalid::Validator
+          validates :list, length: {is: 4}
+        end
+
+        subject(:validator) { ExactLengthValidator.validate(thing) }
+
+        it 'returns a validation result' do
+          expect(validator).to be_a(Subvalid::ValidationResult)
+        end
+
+        context 'when the length is just right' do
+          let(:list) { 'a' * 4 }
+          it { is_expected.to be_valid }
+        end
+
+        context 'when the length is too short' do
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when the length is too long' do
+          let(:list) { 'a' * 5 }
+          it { is_expected.not_to be_valid }
+
+          it 'shows the default error message' do
+            expect(validator.children[:list].errors).to include("should have exactly 4 characters")
+          end
+        end
+      end
+
+      context 'with a range' do
+        context 'when using within' do
+          class WithinValidator
+            include Subvalid::Validator
+            validates :list, length: {within: 2..4}
+          end
+
+          subject(:validator) { WithinValidator.validate(thing) }
+
+          it 'returns a validation result' do
+            expect(validator).to be_a(Subvalid::ValidationResult)
+          end
+
+          context 'when the length is just right' do
+            let(:list) { 'a' * 3 }
+            it { is_expected.to be_valid }
+          end
+
+          context 'when the length is too short' do
+            it { is_expected.not_to be_valid }
+          end
+
+          context 'when the length is too long' do
+            let(:list) { 'a' * 5 }
+            it { is_expected.not_to be_valid }
+
+            it 'shows the default error message' do
+              expect(validator.children[:list].errors).to include("should contain 2 to 4 characters")
+            end
+          end
+        end
+
+        context 'when using in' do
+          class InValidator
+            include Subvalid::Validator
+            validates :list, length: {in: 2..4}
+          end
+
+          subject(:validator) { InValidator.validate(thing) }
+
+          it 'returns a validation result' do
+            expect(validator).to be_a(Subvalid::ValidationResult)
+          end
+
+          context 'when the length is just right' do
+            let(:list) { 'a' * 3 }
+            it { is_expected.to be_valid }
+          end
+
+          context 'when the length is too short' do
+            it { is_expected.not_to be_valid }
+          end
+
+          context 'when the length is too long' do
+            let(:list) { 'a' * 5 }
+            it { is_expected.not_to be_valid }
+
+            it 'shows the default error message' do
+              expect(validator.children[:list].errors).to include("should contain 2 to 4 characters")
+            end
+          end
+        end
+      end
     end
 
-    context 'when the length is just right' do
-      let(:list) { [:a] * 3 }
-      it { is_expected.to be_valid }
-    end
+    context 'when attribute is an array' do
+      context 'with custom message' do
+        class MaxWithMessageValidator
+          include Subvalid::Validator
+          validates :list, length: {maximum: 4, message: "cannot contain more than 5 items"}
+        end
 
-    context 'when the length is too short' do
-      it { is_expected.not_to be_valid }
-    end
+        subject(:validator) { MaxWithMessageValidator.validate(thing) }
 
-    context 'when the length is too long' do
-      let(:list) { [:a] * 5 }
-      it { is_expected.not_to be_valid }
+        context 'when there are too many elements' do
+          context 'with provided message' do
+            let(:list) { [:a] * 5 }
+
+            it 'shows custom error message' do
+              expect(validator.children[:list].errors).to include("cannot contain more than 5 items")
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/subvalid/validators/length_validator_spec.rb
+++ b/spec/subvalid/validators/length_validator_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe Subvalid::Validators::LengthValidator do
+  Thing = Struct.new(:list)
+  class ThingValidator
+    include Subvalid::Validator
+    validates :list, length: {minimum: 2, maximum: 4}
+  end
+
+  let(:thing) { Thing.new(list) }
+  let(:list) { [] }
+
+  describe '#validate' do
+    subject(:validator) { ThingValidator.validate(thing) }
+
+    it 'returns a validation result' do
+      expect(validator).to be_a(Subvalid::ValidationResult)
+    end
+
+    context 'when the length is just right' do
+      let(:list) { [:a] * 3 }
+      it { is_expected.to be_valid }
+    end
+
+    context 'when the length is too short' do
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when the length is too long' do
+      let(:list) { [:a] * 5 }
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/subvalid.gemspec
+++ b/subvalid.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 1.17"
+  spec.add_development_dependency "rake", ">= 12.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
 end

--- a/subvalid.gemspec
+++ b/subvalid.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
 end

--- a/subvalid.gemspec
+++ b/subvalid.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", ">= 1.17"
-  spec.add_development_dependency "rake", ">= 12.0"
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
Context
---

We'd like to customise messages for the length validator and while I'm there, also added more options updating @nocache's PR #3 

Usage
---

``` ruby
class TextValidator
  includes Subvalid::Validator

  validates :text, length: { maximum: 100, message: "cannot be longer than 100 characters" }
end
```

cc @madlep 